### PR TITLE
Adiciona tela de checkout

### DIFF
--- a/app/(tabs)/cart.tsx
+++ b/app/(tabs)/cart.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Minus, Plus, Trash2 } from 'lucide-react-native';
+import { router } from 'expo-router';
 
 type CartItem = {
   id: number;
@@ -117,7 +118,15 @@ export default function Cart() {
           <Text style={styles.totalLabel}>Total</Text>
           <Text style={styles.totalValue}>${total.toFixed(2)}</Text>
         </View>
-        <TouchableOpacity style={styles.checkoutButton}>
+        <TouchableOpacity
+          style={styles.checkoutButton}
+          onPress={() =>
+            router.push({
+              pathname: '/checkout',
+              params: { total: total.toFixed(2) },
+            })
+          }
+        >
           <Text style={styles.checkoutButtonText}>Proceed to Checkout</Text>
         </TouchableOpacity>
       </View>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -29,6 +29,7 @@ export default function RootLayout() {
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="(auth)" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="checkout" options={{ headerShown: false }} />
       </Stack>
       <StatusBar style="auto" />
     </>

--- a/app/checkout.tsx
+++ b/app/checkout.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { StyleSheet, Text, View, TouchableOpacity, Alert } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useLocalSearchParams } from 'expo-router';
+
+export default function Checkout() {
+  const [isPaying, setIsPaying] = useState(false);
+  const { total } = useLocalSearchParams<{ total?: string }>();
+
+  const handlePayment = () => {
+    setIsPaying(true);
+    setTimeout(() => {
+      setIsPaying(false);
+      Alert.alert('Pagamento', 'Compra finalizada com sucesso!');
+    }, 1000);
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Checkout</Text>
+      </View>
+      <View style={styles.content}>
+        <Text style={styles.label}>Valor total</Text>
+        <Text style={styles.total}>${total ?? '0.00'}</Text>
+        <TouchableOpacity
+          style={[styles.payButton, isPaying && styles.payButtonDisabled]}
+          onPress={handlePayment}
+          disabled={isPaying}
+        >
+          <Text style={styles.payButtonText}>Pagar Agora</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  header: {
+    padding: 24,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    color: '#1a1a1a',
+  },
+  content: {
+    padding: 24,
+  },
+  label: {
+    fontSize: 16,
+    color: '#666',
+    marginBottom: 8,
+  },
+  total: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#1a1a1a',
+    marginBottom: 24,
+  },
+  payButton: {
+    backgroundColor: '#1a1a1a',
+    borderRadius: 12,
+    height: 56,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  payButtonDisabled: {
+    opacity: 0.7,
+  },
+  payButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});


### PR DESCRIPTION
## Summary
- cria `checkout.tsx` para simular pagamento
- adiciona rota de `checkout` no layout principal
- botão de checkout no carrinho agora navega para a nova tela passando o total

## Testing
- `npm run lint` *(falhou: expo não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b6c54f483228bf9073e39705c02