### PR TITLE
Add full checkout with navigation

### DIFF
--- a/app/checkout.tsx
+++ b/app/checkout.tsx
@@ -1,11 +1,24 @@
 import { useState } from 'react';
-import { StyleSheet, Text, View, TouchableOpacity, Alert } from 'react-native';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  Alert,
+  TextInput,
+  ScrollView,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams } from 'expo-router';
+import BottomNavigation from '@/components/BottomNavigation';
+import { CreditCard, User, Calendar, Lock } from 'lucide-react-native';
 
 export default function Checkout() {
   const [isPaying, setIsPaying] = useState(false);
   const { total } = useLocalSearchParams<{ total?: string }>();
+  const totalValue = parseFloat(total ?? '0');
+  const shipping = 10;
+  const subtotal = Math.max(totalValue - shipping, 0);
 
   const handlePayment = () => {
     setIsPaying(true);
@@ -20,9 +33,54 @@ export default function Checkout() {
       <View style={styles.header}>
         <Text style={styles.title}>Checkout</Text>
       </View>
-      <View style={styles.content}>
-        <Text style={styles.label}>Valor total</Text>
-        <Text style={styles.total}>${total ?? '0.00'}</Text>
+
+      <ScrollView
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.sectionTitle}>Resumo do Pedido</Text>
+        <View style={styles.summaryRow}>
+          <Text style={styles.summaryLabel}>Subtotal</Text>
+          <Text style={styles.summaryValue}>${subtotal.toFixed(2)}</Text>
+        </View>
+        <View style={styles.summaryRow}>
+          <Text style={styles.summaryLabel}>Frete</Text>
+          <Text style={styles.summaryValue}>${shipping.toFixed(2)}</Text>
+        </View>
+        <View style={[styles.summaryRow, styles.totalRow]}>
+          <Text style={styles.totalLabel}>Total</Text>
+          <Text style={styles.totalValue}>${totalValue.toFixed(2)}</Text>
+        </View>
+
+        <Text style={[styles.sectionTitle, { marginTop: 24 }]}>Pagamento</Text>
+        <View style={styles.inputContainer}>
+          <CreditCard size={20} color="#666" style={styles.inputIcon} />
+          <TextInput
+            style={styles.input}
+            placeholder="Número do cartão"
+            keyboardType="number-pad"
+          />
+        </View>
+        <View style={styles.inputContainer}>
+          <User size={20} color="#666" style={styles.inputIcon} />
+          <TextInput style={styles.input} placeholder="Nome impresso no cartão" />
+        </View>
+        <View style={styles.row}>
+          <View style={[styles.inputContainer, { flex: 1 }]}>
+            <Calendar size={20} color="#666" style={styles.inputIcon} />
+            <TextInput style={styles.input} placeholder="MM/AA" />
+          </View>
+          <View style={{ width: 16 }} />
+          <View style={[styles.inputContainer, { flex: 1 }]}>
+            <Lock size={20} color="#666" style={styles.inputIcon} />
+            <TextInput
+              style={styles.input}
+              placeholder="CVC"
+              keyboardType="number-pad"
+            />
+          </View>
+        </View>
+
         <TouchableOpacity
           style={[styles.payButton, isPaying && styles.payButtonDisabled]}
           onPress={handlePayment}
@@ -30,7 +88,9 @@ export default function Checkout() {
         >
           <Text style={styles.payButtonText}>Pagar Agora</Text>
         </TouchableOpacity>
-      </View>
+      </ScrollView>
+
+      <BottomNavigation />
     </SafeAreaView>
   );
 }
@@ -50,17 +110,64 @@ const styles = StyleSheet.create({
   },
   content: {
     padding: 24,
+    gap: 16,
   },
-  label: {
-    fontSize: 16,
-    color: '#666',
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#1a1a1a',
     marginBottom: 8,
   },
-  total: {
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  summaryLabel: {
+    fontSize: 16,
+    color: '#666',
+  },
+  summaryValue: {
+    fontSize: 16,
+    color: '#1a1a1a',
+  },
+  totalRow: {
+    marginTop: 8,
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: '#f1f1f1',
+  },
+  totalLabel: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#1a1a1a',
+  },
+  totalValue: {
     fontSize: 24,
     fontWeight: 'bold',
     color: '#1a1a1a',
-    marginBottom: 24,
+  },
+  inputContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#e1e1e1',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    height: 56,
+    marginTop: 4,
+  },
+  inputIcon: {
+    marginRight: 12,
+  },
+  input: {
+    flex: 1,
+    fontSize: 16,
+    color: '#1a1a1a',
+  },
+  row: {
+    flexDirection: 'row',
+    marginTop: 4,
   },
   payButton: {
     backgroundColor: '#1a1a1a',

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,0 +1,68 @@
+import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { router, usePathname } from 'expo-router';
+import { Home, Search, ShoppingBag, Heart, User } from 'lucide-react-native';
+
+export default function BottomNavigation() {
+  const pathname = usePathname();
+
+  const items = [
+    { icon: Home, label: 'Home', path: '/' },
+    { icon: Search, label: 'Search', path: '/search' },
+    { icon: ShoppingBag, label: 'Cart', path: '/cart' },
+    { icon: Heart, label: 'Favorites', path: '/favorites' },
+    { icon: User, label: 'Profile', path: '/profile' },
+  ];
+
+  const isActive = (path: string) => {
+    if (path === '/cart') {
+      return pathname === '/cart' || pathname === '/checkout';
+    }
+    return pathname === path;
+  };
+
+  return (
+    <View style={styles.container}>
+      {items.map(item => (
+        <TouchableOpacity
+          key={item.path}
+          style={styles.item}
+          onPress={() => router.replace(item.path)}
+        >
+          <item.icon
+            size={24}
+            color={isActive(item.path) ? '#1a1a1a' : '#666'}
+          />
+          <Text
+            style={[
+              styles.label,
+              { color: isActive(item.path) ? '#1a1a1a' : '#666' },
+            ]}
+          >
+            {item.label}
+          </Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    borderTopColor: '#f1f1f1',
+    borderTopWidth: 1,
+    height: 64,
+    paddingBottom: 8,
+    paddingTop: 8,
+  },
+  item: {
+    alignItems: 'center',
+    gap: 4,
+  },
+  label: {
+    fontSize: 12,
+  },
+});


### PR DESCRIPTION
## Summary
- create bottom navigation component
- redesign checkout screen with order summary and card form

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: expo not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683f4da83ab083228a8d30ba176dced4