### PR TITLE
Add product details page with cart integration

### DIFF
--- a/app/(tabs)/cart.tsx
+++ b/app/(tabs)/cart.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   StyleSheet,
   Text,
@@ -10,46 +9,10 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Minus, Plus, Trash2 } from 'lucide-react-native';
 import { router } from 'expo-router';
-
-type CartItem = {
-  id: number;
-  name: string;
-  price: number;
-  image: string;
-  quantity: number;
-};
+import { useCart, CartItem } from '@/context/CartContext';
 
 export default function Cart() {
-  const [cartItems, setCartItems] = useState<CartItem[]>([
-    {
-      id: 1,
-      name: 'Classic White Sneakers',
-      price: 89.99,
-      image: 'https://images.unsplash.com/photo-1549298916-b41d501d3772',
-      quantity: 1,
-    },
-    {
-      id: 2,
-      name: 'Denim Jacket',
-      price: 129.99,
-      image: 'https://images.unsplash.com/photo-1601933973783-43cf8a7d4c5f',
-      quantity: 2,
-    },
-  ]);
-
-  const updateQuantity = (id: number, change: number) => {
-    setCartItems(prev =>
-      prev.map(item =>
-        item.id === id
-          ? { ...item, quantity: Math.max(1, item.quantity + change) }
-          : item
-      )
-    );
-  };
-
-  const removeItem = (id: number) => {
-    setCartItems(prev => prev.filter(item => item.id !== id));
-  };
+  const { items: cartItems, updateQuantity, removeItem } = useCart();
 
   const subtotal = cartItems.reduce(
     (sum, item) => sum + item.price * item.quantity,
@@ -60,27 +23,27 @@ export default function Cart() {
 
   const renderItem = ({ item }: { item: CartItem }) => (
     <View style={styles.cartItem}>
-      <Image source={{ uri: item.image }} style={styles.itemImage} />
+      <Image source={{ uri: item.imageUrl }} style={styles.itemImage} />
       <View style={styles.itemInfo}>
         <Text style={styles.itemName}>{item.name}</Text>
         <Text style={styles.itemPrice}>${item.price}</Text>
         <View style={styles.quantityControls}>
           <TouchableOpacity
             style={styles.quantityButton}
-            onPress={() => updateQuantity(item.id, -1)}
+            onPress={() => updateQuantity(String(item.id), item.quantity - 1)}
           >
             <Minus size={16} color="#666" />
           </TouchableOpacity>
           <Text style={styles.quantity}>{item.quantity}</Text>
           <TouchableOpacity
             style={styles.quantityButton}
-            onPress={() => updateQuantity(item.id, 1)}
+            onPress={() => updateQuantity(String(item.id), item.quantity + 1)}
           >
             <Plus size={16} color="#666" />
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.removeButton}
-            onPress={() => removeItem(item.id)}
+            onPress={() => removeItem(String(item.id))}
           >
             <Trash2 size={16} color="#dc2626" />
           </TouchableOpacity>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Heart } from 'lucide-react-native';
+import { router } from 'expo-router';
 
 // FIREBASE
 import { collection, getDocs } from 'firebase/firestore';
@@ -58,7 +59,12 @@ export default function Home() {
   };
 
   const renderProduct = ({ item }) => (
-    <View style={styles.productCard}>
+    <TouchableOpacity
+      style={styles.productCard}
+      onPress={() =>
+        router.push({ pathname: '/product/[id]', params: { id: item.id } })
+      }
+    >
       <Image source={{ uri: item.imageUrl }} style={styles.productImage} />
       <TouchableOpacity
         style={styles.favoriteButton}
@@ -74,7 +80,7 @@ export default function Home() {
         <Text style={styles.productName}>{item.name}</Text>
         <Text style={styles.productPrice}>${item.price}</Text>
       </View>
-    </View>
+    </TouchableOpacity>
   );
 
   return (

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Search as SearchIcon } from 'lucide-react-native';
+import { router } from 'expo-router';
 
 const PRODUCTS = [
   {
@@ -51,7 +52,12 @@ export default function Search() {
   );
 
   const renderItem = ({ item }) => (
-    <TouchableOpacity style={styles.productCard}>
+    <TouchableOpacity
+      style={styles.productCard}
+      onPress={() =>
+        router.push({ pathname: '/product/[id]', params: { id: item.id } })
+      }
+    >
       <Image source={{ uri: item.image }} style={styles.productImage} />
       <View style={styles.productInfo}>
         <Text style={styles.productName}>{item.name}</Text>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
+import { CartProvider } from '@/context/CartContext';
 
 //IMPORTACAO FIREBASECONFIG
 import '@/firebaseConfig';
@@ -25,13 +26,14 @@ export default function RootLayout() {
   }, []);
 
   return (
-    <>
+    <CartProvider>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="(auth)" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="checkout" options={{ headerShown: false }} />
+        <Stack.Screen name="product/[id]" options={{ headerShown: false }} />
       </Stack>
       <StatusBar style="auto" />
-    </>
+    </CartProvider>
   );
 }

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import { StyleSheet, Text, View, Image, TouchableOpacity, ScrollView } from 'react-native';
+import { useLocalSearchParams, router } from 'expo-router';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '@/firebaseConfig';
+import { useCart } from '@/context/CartContext';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ArrowLeft } from 'lucide-react-native';
+
+export default function ProductDetail() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [product, setProduct] = useState<any>(null);
+  const { addItem } = useCart();
+
+  useEffect(() => {
+    if (!id) return;
+    const fetchProduct = async () => {
+      try {
+        const docRef = doc(db, 'products', String(id));
+        const snap = await getDoc(docRef);
+        if (snap.exists()) {
+          setProduct({ id: snap.id, ...snap.data() });
+        }
+      } catch (err) {
+        console.error('Fetch product error', err);
+      }
+    };
+    fetchProduct();
+  }, [id]);
+
+  if (!product) {
+    return (
+      <SafeAreaView style={styles.loaderContainer}>
+        <Text>Loading...</Text>
+      </SafeAreaView>
+    );
+  }
+
+  const handleAdd = () => {
+    addItem({ id: String(product.id), name: product.name, price: product.price, imageUrl: product.imageUrl });
+    router.replace('/cart');
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+          <ArrowLeft size={24} color="#1a1a1a" />
+        </TouchableOpacity>
+        <Image source={{ uri: product.imageUrl }} style={styles.image} />
+        <View style={styles.info}>
+          <Text style={styles.name}>{product.name}</Text>
+          <Text style={styles.price}>${product.price}</Text>
+          {product.description && (
+            <Text style={styles.description}>{product.description}</Text>
+          )}
+        </View>
+        <TouchableOpacity style={styles.addButton} onPress={handleAdd}>
+          <Text style={styles.addButtonText}>Add to Cart</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  loaderContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  content: {
+    paddingBottom: 40,
+  },
+  backButton: {
+    margin: 16,
+  },
+  image: {
+    width: '100%',
+    height: 300,
+  },
+  info: {
+    padding: 16,
+  },
+  name: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#1a1a1a',
+    marginBottom: 8,
+  },
+  price: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 16,
+  },
+  description: {
+    fontSize: 16,
+    color: '#666',
+  },
+  addButton: {
+    marginHorizontal: 16,
+    marginTop: 24,
+    backgroundColor: '#1a1a1a',
+    borderRadius: 12,
+    height: 56,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  addButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -1,0 +1,56 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+export type CartItem = {
+  id: string;
+  name: string;
+  price: number;
+  imageUrl: string;
+  quantity: number;
+};
+
+interface CartContextData {
+  items: CartItem[];
+  addItem: (item: Omit<CartItem, 'quantity'>, quantity?: number) => void;
+  updateQuantity: (id: string, qty: number) => void;
+  removeItem: (id: string) => void;
+}
+
+const CartContext = createContext<CartContextData | undefined>(undefined);
+
+export const useCart = () => {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error('CartContext not found');
+  return ctx;
+};
+
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<CartItem[]>([]);
+
+  const addItem = (item: Omit<CartItem, 'quantity'>, quantity: number = 1) => {
+    setItems(prev => {
+      const existing = prev.find(i => i.id === item.id);
+      if (existing) {
+        return prev.map(i =>
+          i.id === item.id ? { ...i, quantity: i.quantity + quantity } : i
+        );
+      }
+      return [...prev, { ...item, quantity }];
+    });
+  };
+
+  const updateQuantity = (id: string, qty: number) => {
+    setItems(prev =>
+      prev.map(i => (i.id === id ? { ...i, quantity: Math.max(1, qty) } : i))
+    );
+  };
+
+  const removeItem = (id: string) => {
+    setItems(prev => prev.filter(i => i.id !== id));
+  };
+
+  return (
+    <CartContext.Provider value={{ items, addItem, updateQuantity, removeItem }}>
+      {children}
+    </CartContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- add cart context for shared cart state
- wrap root layout with `CartProvider`
- implement product detail screen with add-to-cart button
- integrate new screen into home and search lists
- update cart page to use context

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f509ebe648322a2f4a6750421e10b